### PR TITLE
feat: Increase character size and enhance maze visuals

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,7 +9,7 @@
 <body>
   <h1>Turn EatMan</h1>
   <div id="game-container">
-  <canvas id="game-canvas" width="576" height="656"></canvas>
+  <canvas id="game-canvas" width="864" height="984"></canvas>
 <div id="power-timer"></div>
 </div>
 <div id="ui"></div>

--- a/main.js
+++ b/main.js
@@ -9,7 +9,7 @@ const H = canvas.height;
 // マップ設定（シンプルなパックマン風迷路 28x31）
 const MAP_W = 36;
 const MAP_H = 41;
-const TILE = 16;
+const TILE = 24;
 // 0: 通路, 1: 壁, 2: ドット, 3: パワーエサ
 // 必ずスタート地点と敵の周囲を通路に修正（fixList）
 const fixList = [
@@ -464,15 +464,15 @@ function draw() {
   for(let y=0; y<MAP_H; y++) for(let x=0; x<MAP_W; x++) {
     if(!map[y]) continue;
     if(map[y][x] === 1) {
-      ctx.fillStyle = '#22f';
+      ctx.fillStyle = '#55f';
       ctx.fillRect(x*TILE, y*TILE, TILE, TILE);
     } else if(map[y][x] === 2) {
-      ctx.fillStyle = '#ff0';
+      ctx.fillStyle = '#ffff00';
       ctx.beginPath();
       ctx.arc(x*TILE+TILE/2, y*TILE+TILE/2, 2, 0, Math.PI*2);
       ctx.fill();
     } else if(map[y][x] === 3) {
-      ctx.fillStyle = '#0ff';
+      ctx.fillStyle = '#00ffff';
       ctx.beginPath();
       ctx.arc(x*TILE+TILE/2, y*TILE+TILE/2, 5, 0, Math.PI*2);
       ctx.fill();
@@ -481,14 +481,14 @@ function draw() {
   // プレイヤー（パワー状態なら紫、通常は黄色）
   ctx.fillStyle = (powerCount > 0) ? '#c0f' : '#ff0';
   ctx.beginPath();
-  ctx.arc(player.x*TILE+TILE/2, player.y*TILE+TILE/2, 7, 0, Math.PI*2);
+  ctx.arc(player.x*TILE+TILE/2, player.y*TILE+TILE/2, 10, 0, Math.PI*2);
   ctx.fill();
   // モンスター
   ctx.fillStyle = '#f44';
   for(const m of monsters) {
     if(!m.alive) continue;
     ctx.beginPath();
-    ctx.arc(m.x*TILE+TILE/2, m.y*TILE+TILE/2, 7, 0, Math.PI*2);
+    ctx.arc(m.x*TILE+TILE/2, m.y*TILE+TILE/2, 10, 0, Math.PI*2);
     ctx.fill();
   }
   // パワー状態表示（画面下）

--- a/style.css
+++ b/style.css
@@ -10,14 +10,14 @@ h1 {
 }
 #game-container {
   width: 100vw;
-  max-width: 448px;
+  max-width: 672px;
   margin: 0 auto;
 }
 #game-canvas {
   width: 100vw;
-  max-width: 448px;
+  max-width: 672px;
   height: auto;
-  max-height: 496px;
+  max-height: 744px;
   background: #000;
   border: 3px solid #444;
   display: block;
@@ -52,7 +52,7 @@ h1 {
 #touch-controls {
   margin: 18px auto 0 auto;
   width: 100vw;
-  max-width: 448px;
+  max-width: 672px;
   display: flex;
   flex-direction: column;
   align-items: center;


### PR DESCRIPTION
This commit implements the following changes:

- Player and monster character radius increased from 7 to 10 pixels for better visibility.
- Maze tile size increased from 16px to 24px, making pathways wider and the game easier to view.
- Canvas dimensions updated to 864x984 to accommodate the new tile size, with responsive CSS max-width/height adjusted accordingly.
- Touch controls' max-width also updated to match the new canvas responsive width.
- Maze wall color changed from '#22f' to a brighter '#55f'.
- Dot color explicitly set to '#ffff00' (yellow).
- Power pellet color explicitly set to '#00ffff' (cyan).

These changes aim to make the game character larger and the maze more colorful and easier to see, as per your request.